### PR TITLE
Update translations (Chinese part)

### DIFF
--- a/src/main/resources/langs/language_zh.properties
+++ b/src/main/resources/langs/language_zh.properties
@@ -1,14 +1,14 @@
 file=文件
 file.openFile=打开文件
-file.newInstance=新实例
-file.exit=出口
+file.newInstance=打开新窗口
+file.exit=退出
 
 help=帮助
 
-empty=没有文件打开
-empty.drag=拖放打开
+empty=空空如也
+empty.drag=将文件拖放到此处打开
 
 about=关于
 about.version=版本 %s
 about.vm=虚拟机
-about.ok=好的
+about.ok=关闭


### PR DESCRIPTION
As a native speaker, I am honored to contribute this repo. The following are my reasons for making this commit:

- It is correct for `Exit` to be translated as `出口` as a noun, but in the menu, it should be translated as `退出` as a verb.
- `打开新窗口` is a more commonly used translation for `New Instance`. `新实例` is usually only used by developers, not users.
- Use idiom `空空如也` to representate `No file is open` is a better choice.
- Complete the translation of `Drag and drop to open`.

Please @mention me if there are more text that needs to be translated.

（\*＾-＾\*）